### PR TITLE
Add simple PHP prompt generator with admin panel

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# prompt-image-generator
+# Prompt Image Generator
+
+Ferramenta simples para criação de prompts estruturados para geração de imagens. Construída em PHP 8, MySQL e Tailwind CSS.
+
+## Requisitos
+- PHP 8.0+
+- MySQL
+- Apache com **mod_rewrite**
+- Extensões PHP: `pdo_mysql`, `gd` ou `imagick`, `fileinfo`, `json`, `session`
+
+## Instalação no Hostgator (cPanel)
+1. Faça upload do projeto para `public_html` ou subdomínio e extraia os arquivos.
+2. Crie um Banco MySQL e usuário com todas as permissões.
+3. Importe o arquivo `db/install.sql` para criar as tabelas e dados iniciais.
+4. Edite `config/database.php` com as credenciais do banco e URL do site.
+5. Ajuste permissões:
+   - `uploads/` → 755 ou 777
+   - arquivos PHP → 644
+6. Ative logs de erro no `php.ini` ou `.user.ini`.
+7. Certifique-se de que as diretivas PHP atendem:
+   - `upload_max_filesize=5M`
+   - `post_max_size=50M`
+   - `max_execution_time=300`
+   - `memory_limit=256M`
+   - `max_input_vars=3000`
+8. Ative SSL/HTTPS e mantenha o `.htaccess` com redirecionamento.
+
+## Uso
+- Acesse o site para montar o prompt selecionando opções por categoria.
+- O prompt é atualizado em tempo real e pode ser copiado com um clique.
+- Admin: acesse `/admin/login.php` (usuário `admin`, senha `admin123` padrão). Gerencie categorias e opções com upload de imagens.
+
+## Licença
+Uso livre, inclusive comercial. Atribuição opcional.

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+require __DIR__ . '/../config/database.php';
+if (!isset($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+// Add category
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    if ($name) {
+        $stmt = $pdo->prepare('INSERT INTO categories (name) VALUES (?)');
+        $stmt->execute([$name]);
+    }
+}
+// Delete category
+if (isset($_GET['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM categories WHERE id = ?');
+    $stmt->execute([$_GET['delete']]);
+}
+$cats = $pdo->query('SELECT * FROM categories ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+$page_title = 'Categorias';
+include __DIR__ . '/../includes/header.php';
+?>
+<div class="p-6 w-full">
+    <h1 class="text-2xl mb-4">Categorias</h1>
+    <form method="post" class="mb-4 flex gap-2">
+        <input type="text" name="name" placeholder="Nome" class="p-2 bg-gray-700" required />
+        <button class="bg-blue-600 hover:bg-blue-700 text-white px-4">Adicionar</button>
+    </form>
+    <table class="w-full text-left">
+        <tr><th class="p-2">ID</th><th class="p-2">Nome</th><th></th></tr>
+        <?php foreach ($cats as $c): ?>
+        <tr class="border-t border-gray-700"><td class="p-2"><?= $c['id'] ?></td><td class="p-2"><?= htmlspecialchars($c['name']) ?></td><td class="p-2"><a href="?delete=<?= $c['id'] ?>" class="text-red-400" onclick="return confirm('Excluir?')">Excluir</a></td></tr>
+        <?php endforeach; ?>
+    </table>
+</div>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+require __DIR__ . '/../config/database.php';
+if (!isset($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+$page_title = 'Dashboard';
+include __DIR__ . '/../includes/header.php';
+?>
+<div class="p-6">
+    <h1 class="text-2xl mb-4">Dashboard</h1>
+    <div class="space-x-4">
+        <a href="categories.php" class="underline text-blue-400">Categorias</a>
+        <a href="options.php" class="underline text-blue-400">Opções</a>
+        <a href="logout.php" class="underline text-blue-400">Sair</a>
+    </div>
+</div>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+require __DIR__ . '/../config/database.php';
+
+if (isset($_SESSION['admin'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ?');
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && hash('sha256', $password) === $user['password']) {
+        $_SESSION['admin'] = $user['username'];
+        header('Location: dashboard.php');
+        exit;
+    } else {
+        $error = 'Login inválido';
+    }
+}
+$page_title = 'Login Admin';
+include __DIR__ . '/../includes/header.php';
+?>
+<div class="flex-1 flex items-center justify-center">
+    <form method="post" class="bg-gray-800 p-6 rounded w-full max-w-sm">
+        <h1 class="text-xl mb-4">Admin</h1>
+        <?php if ($error): ?><p class="mb-2 text-red-500"><?= $error ?></p><?php endif; ?>
+        <input type="text" name="username" placeholder="Usuário" class="w-full mb-2 p-2 bg-gray-700" required />
+        <input type="password" name="password" placeholder="Senha" class="w-full mb-4 p-2 bg-gray-700" required />
+        <button class="w-full bg-blue-600 hover:bg-blue-700 text-white p-2">Entrar</button>
+    </form>
+</div>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;
+?>

--- a/admin/options.php
+++ b/admin/options.php
@@ -1,0 +1,77 @@
+<?php
+session_start();
+require __DIR__ . '/../config/database.php';
+if (!isset($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+// Handle add option
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $category_id = (int)($_POST['category_id'] ?? 0);
+    $name = trim($_POST['name'] ?? '');
+    $prompt_value = trim($_POST['prompt_value'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $image_path = null;
+    if (!empty($_FILES['image']['name'])) {
+        $filename = time() . '_' . basename($_FILES['image']['name']);
+        $target = __DIR__ . '/../uploads/' . $filename;
+        if (move_uploaded_file($_FILES['image']['tmp_name'], $target)) {
+            $image_path = $filename;
+        }
+    }
+    if ($category_id && $name && $prompt_value) {
+        $stmt = $pdo->prepare('INSERT INTO options (category_id, name, prompt_value, description, image_path) VALUES (?,?,?,?,?)');
+        $stmt->execute([$category_id, $name, $prompt_value, $description, $image_path]);
+    }
+}
+// Delete option
+if (isset($_GET['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM options WHERE id = ?');
+    $stmt->execute([$_GET['delete']]);
+}
+// Categories for select
+$cats = $pdo->query('SELECT * FROM categories ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$filter = (int)($_GET['cat'] ?? 0);
+if ($filter) {
+    $stmt = $pdo->prepare('SELECT o.*, c.name AS cname FROM options o JOIN categories c ON o.category_id=c.id WHERE category_id=? ORDER BY o.id');
+    $stmt->execute([$filter]);
+} else {
+    $stmt = $pdo->query('SELECT o.*, c.name AS cname FROM options o JOIN categories c ON o.category_id=c.id ORDER BY o.id');
+}
+$options = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$page_title = 'Opções';
+include __DIR__ . '/../includes/header.php';
+?>
+<div class="p-6 w-full">
+    <h1 class="text-2xl mb-4">Opções</h1>
+    <form method="post" enctype="multipart/form-data" class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-4">
+        <select name="category_id" class="p-2 bg-gray-700" required>
+            <option value="">Categoria</option>
+            <?php foreach ($cats as $c): ?>
+            <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+        <input type="text" name="name" placeholder="Nome" class="p-2 bg-gray-700" required />
+        <input type="text" name="prompt_value" placeholder="Valor do Prompt" class="p-2 bg-gray-700" required />
+        <input type="file" name="image" class="p-2 bg-gray-700" />
+        <textarea name="description" placeholder="Descrição" class="p-2 bg-gray-700 col-span-full"></textarea>
+        <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 col-span-full">Adicionar</button>
+    </form>
+    <div class="mb-4">
+        <form method="get">
+            <select name="cat" onchange="this.form.submit()" class="p-2 bg-gray-700">
+                <option value="0">-- Todas Categorias --</option>
+                <?php foreach ($cats as $c): ?>
+                <option value="<?= $c['id'] ?>" <?= $filter==$c['id']?'selected':'' ?>><?= htmlspecialchars($c['name']) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </form>
+    </div>
+    <table class="w-full text-left">
+        <tr><th class="p-2">ID</th><th class="p-2">Categoria</th><th class="p-2">Nome</th><th class="p-2">Prompt</th><th></th></tr>
+        <?php foreach ($options as $o): ?>
+        <tr class="border-t border-gray-700"><td class="p-2"><?= $o['id'] ?></td><td class="p-2"><?= htmlspecialchars($o['cname']) ?></td><td class="p-2"><?= htmlspecialchars($o['name']) ?></td><td class="p-2"><?= htmlspecialchars($o['prompt_value']) ?></td><td class="p-2"><a href="?delete=<?= $o['id'] ?>" class="text-red-400" onclick="return confirm('Excluir?')">Excluir</a></td></tr>
+        <?php endforeach; ?>
+    </table>
+</div>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,15 @@
+<?php
+// Database configuration
+$host = 'localhost';
+$db   = 'promptdb';
+$user = 'promptuser';
+$pass = 'promptpass';
+$base_url = 'http://localhost'; // Change to your domain
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('DB Connection failed: ' . $e->getMessage());
+}
+?>

--- a/db/install.sql
+++ b/db/install.sql
@@ -1,0 +1,34 @@
+-- Database installation script
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50) NOT NULL,
+  password VARCHAR(255) NOT NULL
+);
+INSERT INTO users (username, password) VALUES ('admin', SHA2('admin123', 256));
+
+CREATE TABLE categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  active TINYINT DEFAULT 1
+);
+
+CREATE TABLE options (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  category_id INT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  prompt_value VARCHAR(255) NOT NULL,
+  description TEXT,
+  image_path VARCHAR(255),
+  sort_order INT DEFAULT 0,
+  active TINYINT DEFAULT 1,
+  FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+);
+
+-- Exemplo de dados iniciais
+INSERT INTO categories (name) VALUES ('Estilo Fotográfico'), ('Plano'), ('Ângulo');
+INSERT INTO options (category_id, name, prompt_value) VALUES
+(1, 'editorial', 'editorial'),
+(1, 'lifestyle', 'lifestyle'),
+(2, 'close-up', 'close-up'),
+(2, 'plano geral', 'wide shot'),
+(3, 'olho-no-olho', 'eye level');

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer class="bg-gray-800 p-4 text-center">
+    <small>Criado por Agência NEXP</small>
+</footer>
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,24 @@
+<?php
+if (!isset($page_title)) {
+    $page_title = 'Prompt Image Generator';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR" class="h-full bg-gray-900 text-gray-100">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($page_title) ?></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col">
+<header class="bg-gray-800 p-4 flex items-center justify-between">
+    <div class="flex items-center">
+        <img src="https://nexp.com.br/wp-content/uploads/2025/07/logo_nexp.png" alt="Agência NEXP" class="h-8 mr-2"/>
+        <span class="font-semibold">Prompt Image Generator</span>
+    </div>
+    <nav>
+        <a href="<?= $base_url ?>/admin/login.php" class="text-sm text-gray-400 hover:text-white">Admin</a>
+    </nav>
+</header>
+<main class="flex-1 flex">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,103 @@
+<?php
+require __DIR__ . '/config/database.php';
+
+// Fetch categories and options
+$stmt = $pdo->query("SELECT c.id AS cid, c.name AS cname, o.id AS oid, o.name AS oname, o.prompt_value, o.image_path FROM categories c LEFT JOIN options o ON o.category_id = c.id AND o.active=1 WHERE c.active=1 ORDER BY c.id, o.sort_order, o.name");
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$categories = [];
+foreach ($rows as $r) {
+    if (!isset($categories[$r['cid']])) {
+        $categories[$r['cid']] = ['name' => $r['cname'], 'options' => []];
+    }
+    if ($r['oid']) {
+        $categories[$r['cid']]['options'][] = $r;
+    }
+}
+$page_title = 'Gerador de Prompt';
+include __DIR__ . '/includes/header.php';
+?>
+<div class="w-1/4 bg-gray-800 overflow-y-auto">
+    <ul>
+        <?php foreach ($categories as $cid => $cat): ?>
+            <li class="border-b border-gray-700">
+                <button class="w-full text-left p-3 hover:bg-gray-700" onclick="showCategory('cat<?= $cid ?>')">
+                    <?= htmlspecialchars($cat['name']) ?>
+                </button>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</div>
+<div class="flex-1 p-4">
+    <div class="mb-4">
+        <label class="block mb-1">Descrição da Cena</label>
+        <textarea id="scene" class="w-full p-2 bg-gray-700" rows="3" placeholder="Descreva a cena..."></textarea>
+    </div>
+    <?php foreach ($categories as $cid => $cat): ?>
+        <div id="cat<?= $cid ?>" class="category hidden">
+            <h2 class="text-xl mb-2"><?= htmlspecialchars($cat['name']) ?></h2>
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                <?php foreach ($cat['options'] as $opt): ?>
+                    <button class="option border border-gray-600 p-2 flex flex-col items-center" data-category="<?= $cid ?>" data-value="<?= htmlspecialchars($opt['prompt_value']) ?>" onclick="toggleOption(this)">
+                        <?php if ($opt['image_path']): ?>
+                            <img src="uploads/<?= htmlspecialchars($opt['image_path']) ?>" alt="<?= htmlspecialchars($opt['oname']) ?>" class="mb-2 h-16 object-cover"/>
+                        <?php endif; ?>
+                        <span><?= htmlspecialchars($opt['oname']) ?></span>
+                    </button>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endforeach; ?>
+    <div class="mt-4">
+        <label class="block mb-1">Prompt Gerado</label>
+        <textarea id="promptOutput" class="w-full p-2 bg-gray-700" rows="3" readonly></textarea>
+        <div class="mt-2 flex gap-2">
+            <button onclick="copyPrompt()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2">Copiar</button>
+            <button onclick="clearAll()" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2">Limpar</button>
+        </div>
+    </div>
+</div>
+<script>
+const selections = {};
+function showCategory(id){
+    document.querySelectorAll('.category').forEach(c=>c.classList.add('hidden'));
+    document.getElementById(id).classList.remove('hidden');
+}
+function toggleOption(btn){
+    const cat = btn.dataset.category;
+    const value = btn.dataset.value;
+    if(selections[cat] === value){
+        delete selections[cat];
+        btn.classList.remove('bg-blue-600');
+    } else {
+        // clear previous selection in this category
+        document.querySelectorAll('.option[data-category="'+cat+'"]').forEach(o=>o.classList.remove('bg-blue-600'));
+        selections[cat] = value;
+        btn.classList.add('bg-blue-600');
+    }
+    generatePrompt();
+}
+function generatePrompt(){
+    const scene = document.getElementById('scene').value.trim();
+    const values = Object.values(selections);
+    const prompt = (scene? scene + ', ' : '') + values.join(', ');
+    document.getElementById('promptOutput').value = prompt;
+}
+function copyPrompt(){
+    const txt = document.getElementById('promptOutput');
+    txt.select();
+    document.execCommand('copy');
+}
+function clearAll(){
+    Object.keys(selections).forEach(k=>delete selections[k]);
+    document.querySelectorAll('.option').forEach(o=>o.classList.remove('bg-blue-600'));
+    document.getElementById('scene').value = '';
+    document.getElementById('promptOutput').value = '';
+}
+// show first category
+<?php if ($categories): $first = array_key_first($categories); ?>
+showCategory('cat<?= $first ?>');
+<?php endif; ?>
+</script>
+<?php
+include __DIR__ . '/includes/footer.php';
+?>


### PR DESCRIPTION
## Summary
- Build basic PHP/Tailwind app to select options and create image prompts
- Add minimal admin panel with login, category and option management and image upload
- Provide Hostgator-ready setup instructions and sample database schema

## Testing
- `for f in $(find . -name "*.php"); do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68b590a8c690833399fca41b4b1a1f6e